### PR TITLE
configurable installCommand

### DIFF
--- a/src/main/kotlin/DependenciesInstallTask.kt
+++ b/src/main/kotlin/DependenciesInstallTask.kt
@@ -38,7 +38,8 @@ abstract class DependenciesInstallTask : DefaultTask() {
     fun run() {
         val workingDir = packageJson.get().asFile.parentFile //TODO: use workingDir from NodePluginExtension
         val packageManager = project.extensions.getByType<NodePluginExtension>().packageManager.get()
-        val process = getNodeService().get().executeCommand(this, packageManager, "install", *args.get().toTypedArray())
+        val installCommand = project.extensions.getByType<NodePluginExtension>().installCommand.get()
+        val process = getNodeService().get().executeCommand(this, packageManager, installCommand, *args.get().toTypedArray())
         process.waitFor()
         if (process.exitValue() != 0) {
             if (!ignoreExitValue.get()) {

--- a/src/main/kotlin/NodePlugin.kt
+++ b/src/main/kotlin/NodePlugin.kt
@@ -35,6 +35,7 @@ class NodePlugin : Plugin<Project> {
         extension.tasksDependingOnNodeInstallByDefault.convention(true)
         extension.scriptsDependingOnNodeDevInstall.convention(hashSetOf())
         extension.scriptsDependingOnNodeInstall.convention(hashSetOf())
+        extension.installCommand.convention("install")
         extension.nodeVersion.convention("18.15.0")
         extension.nodePath.convention("")
         extension.verbose.convention(true)

--- a/src/main/kotlin/NodePluginExtension.kt
+++ b/src/main/kotlin/NodePluginExtension.kt
@@ -12,6 +12,7 @@ interface NodePluginExtension {
     val tasksDependingOnNodeInstallByDefault: Property<Boolean>
     val scriptsDependingOnNodeDevInstall: SetProperty<String>
     val scriptsDependingOnNodeInstall: SetProperty<String>
+    val installCommand: Property<String>
     val nodeVersion: Property<String>
     val nodePath: Property<String>
     val downloadNode: Property<Boolean>


### PR DESCRIPTION
Adds the ability to override the install command so you can change it to `ci` when install from a CI pipeline.

Wasn't sure if you wanted a README update for this till the README is swapped over to the 1.4.2 syntax.