### PR TITLE
Clean task name config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ node {
     downloadNode.set(true)
     verbose.set(true)
     packageManager.set(PackageManager.NPM)
+    installCommand.set(if (isCI) "ci" else "install")
+    cleanTaskName.set("nodeClean")
 }
 
 // Example to further configure tasks extracted from scripts in package.json
@@ -135,6 +137,8 @@ node {
     downloadNode.set(true)
     verbose.set(true)
     packageManager.set(PackageManager.NPM)
+    installCommand.set('ci')
+    cleanTaskName.set("nodeClean")
 }
 
 // Example to further configure tasks extracted from scripts in package.json

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ node {
     verbose.set(true)
     packageManager.set(PackageManager.NPM)
     installCommand.set('ci')
-    cleanTaskName.set("nodeClean")
+    cleanTaskName.set('nodeClean')
 }
 
 // Example to further configure tasks extracted from scripts in package.json

--- a/src/main/kotlin/NodeCleanTask.kt
+++ b/src/main/kotlin/NodeCleanTask.kt
@@ -1,12 +1,16 @@
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.getByType
 
 abstract class NodeCleanTask : DefaultTask() {
 
     companion object {
-        const val NAME = "clean"
+        fun getName (project: Project): String {
+            return project.extensions.getByType<NodePluginExtension>().cleanTaskName.get()
+        }
     }
 
     @get:InputDirectory

--- a/src/main/kotlin/NodePlugin.kt
+++ b/src/main/kotlin/NodePlugin.kt
@@ -38,7 +38,7 @@ class NodePlugin : Plugin<Project> {
         extension.scriptsDependingOnNodeDevInstall.convention(hashSetOf())
         extension.scriptsDependingOnNodeInstall.convention(hashSetOf())
         extension.installCommand.convention("install")
-        extension.cleanTaskName.convention("clean")
+        extension.cleanTaskName.convention(DEFAULT_CLEAN_TASK_NAME)
         extension.nodeVersion.convention("18.19.0")
         extension.nodePath.convention("")
         extension.verbose.convention(true)
@@ -47,6 +47,8 @@ class NodePlugin : Plugin<Project> {
     }
 
     companion object {
+        private const val DEFAULT_CLEAN_TASK_NAME = "clean"
+
         fun registerTasks(project: Project) {
             val extension = project.extensions.getByType<NodePluginExtension>()
 
@@ -92,6 +94,10 @@ class NodePlugin : Plugin<Project> {
             project.tasks.register<NodeCleanTask>(NodeCleanTask.getName(project)) {
                 group = BasePlugin.CLEAN_TASK_NAME
                 nodeModules.convention(extension.nodeModules)
+                // If the cleanTaskName is set, make the new task depend on clean
+                if (extension.cleanTaskName.get() != DEFAULT_CLEAN_TASK_NAME) {
+                    dependsOn(DEFAULT_CLEAN_TASK_NAME)
+                }
             }
 
             // Register package.json scripts as gradle tasks

--- a/src/main/kotlin/NodePlugin.kt
+++ b/src/main/kotlin/NodePlugin.kt
@@ -92,13 +92,17 @@ class NodePlugin : Plugin<Project> {
 
             // Register the clean task to delete node_modules
             project.tasks.register<NodeCleanTask>(NodeCleanTask.getName(project)) {
-                group = BasePlugin.CLEAN_TASK_NAME
+                group = extension.defaultTaskGroup.get()
                 nodeModules.convention(extension.nodeModules)
-                // If the cleanTaskName is set, make the new task depend on clean
-                if (extension.cleanTaskName.get() != DEFAULT_CLEAN_TASK_NAME) {
-                    dependsOn(DEFAULT_CLEAN_TASK_NAME)
+            }
+
+            // If cleanTaskName is set, make our clean task a dependency of the default
+            if (extension.cleanTaskName.get() != DEFAULT_CLEAN_TASK_NAME) {
+                project.tasks.named(DEFAULT_CLEAN_TASK_NAME)  {
+                    dependsOn(extension.cleanTaskName.get())
                 }
             }
+
 
             // Register package.json scripts as gradle tasks
             val scripts = packageJson.get("scripts").asJsonObject

--- a/src/main/kotlin/NodePlugin.kt
+++ b/src/main/kotlin/NodePlugin.kt
@@ -38,6 +38,7 @@ class NodePlugin : Plugin<Project> {
         extension.scriptsDependingOnNodeDevInstall.convention(hashSetOf())
         extension.scriptsDependingOnNodeInstall.convention(hashSetOf())
         extension.installCommand.convention("install")
+        extension.cleanTaskName.convention("clean")
         extension.nodeVersion.convention("18.19.0")
         extension.nodePath.convention("")
         extension.verbose.convention(true)
@@ -88,7 +89,7 @@ class NodePlugin : Plugin<Project> {
             }
 
             // Register the clean task to delete node_modules
-            project.tasks.register<NodeCleanTask>(NodeCleanTask.NAME) {
+            project.tasks.register<NodeCleanTask>(NodeCleanTask.getName(project)) {
                 group = BasePlugin.CLEAN_TASK_NAME
                 nodeModules.convention(extension.nodeModules)
             }

--- a/src/main/kotlin/NodePlugin.kt
+++ b/src/main/kotlin/NodePlugin.kt
@@ -92,7 +92,7 @@ class NodePlugin : Plugin<Project> {
 
             // Register the clean task to delete node_modules
             project.tasks.register<NodeCleanTask>(NodeCleanTask.getName(project)) {
-                group = extension.defaultTaskGroup.get()
+                group = BasePlugin.CLEAN_TASK_NAME
                 nodeModules.convention(extension.nodeModules)
             }
 

--- a/src/main/kotlin/NodePlugin.kt
+++ b/src/main/kotlin/NodePlugin.kt
@@ -38,7 +38,7 @@ class NodePlugin : Plugin<Project> {
         extension.scriptsDependingOnNodeDevInstall.convention(hashSetOf())
         extension.scriptsDependingOnNodeInstall.convention(hashSetOf())
         extension.installCommand.convention("install")
-        extension.cleanTaskName.convention(DEFAULT_CLEAN_TASK_NAME)
+        extension.cleanTaskName.convention(BasePlugin.CLEAN_TASK_NAME)
         extension.nodeVersion.convention("18.19.0")
         extension.nodePath.convention("")
         extension.verbose.convention(true)
@@ -47,8 +47,6 @@ class NodePlugin : Plugin<Project> {
     }
 
     companion object {
-        private const val DEFAULT_CLEAN_TASK_NAME = "clean"
-
         fun registerTasks(project: Project) {
             val extension = project.extensions.getByType<NodePluginExtension>()
 
@@ -97,8 +95,8 @@ class NodePlugin : Plugin<Project> {
             }
 
             // If cleanTaskName is set, make our clean task a dependency of the default
-            if (extension.cleanTaskName.get() != DEFAULT_CLEAN_TASK_NAME) {
-                project.tasks.named(DEFAULT_CLEAN_TASK_NAME)  {
+            if (extension.cleanTaskName.get() != BasePlugin.CLEAN_TASK_NAME) {
+                project.tasks.named(BasePlugin.CLEAN_TASK_NAME)  {
                     dependsOn(extension.cleanTaskName.get())
                 }
             }

--- a/src/main/kotlin/NodePluginExtension.kt
+++ b/src/main/kotlin/NodePluginExtension.kt
@@ -13,6 +13,7 @@ interface NodePluginExtension {
     val scriptsDependingOnNodeDevInstall: SetProperty<String>
     val scriptsDependingOnNodeInstall: SetProperty<String>
     val installCommand: Property<String>
+    val cleanTaskName: Property<String>
     val nodeVersion: Property<String>
     val nodePath: Property<String>
     val downloadNode: Property<Boolean>


### PR DESCRIPTION
adds a new `cleanTaskName` option for renaming the clean task to prevent task name conflicts