### PR TITLE
use args list for node scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ tasks.named<NodeScriptTask>("build") {
     // Other optional properties
     ignoreExitValue.set(false) // default true
     command.set("run")
-    args.set("")
+    args.set(listOf(""))
     packageManager.set(PackageManager.NPM)
 }
 
@@ -151,6 +151,9 @@ tasks.named('build') {
     // Configure the task inputs and outputs to allow for up-to-date checks
     inputs.dir('src')
     outputs.dir('dist')
+
+    // Other optional properties
+    args.set(new ArrayList<>())
 }
 
 NodeService serviceProvider = (NodeService) project.gradle.sharedServices.registrations.getByName(NodeService.NAME)

--- a/src/main/kotlin/NodeScriptTask.kt
+++ b/src/main/kotlin/NodeScriptTask.kt
@@ -1,4 +1,5 @@
 import org.gradle.api.DefaultTask
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -17,19 +18,20 @@ abstract class NodeScriptTask : DefaultTask() {
     abstract val command: Property<String>
 
     @get:Input
-    abstract val args: Property<String>
+    abstract val args: ListProperty<String>
 
     @get:Input
     abstract val packageManager: Property<PackageManager>
 
     init {
         description = "Run node script of the name of the task"
+        args.convention(listOf())
     }
 
     @TaskAction
     fun run() {
         val nodeService = getNodeService().get()
-        val process = nodeService.executeCommand(this, packageManager.get(), command.get(), args.get())
+        val process = nodeService.executeCommand(this, packageManager.get(), command.get(), *args.get().toTypedArray())
         process.waitFor()
         if (process.exitValue() != 0) {
             if (!ignoreExitValue.get()) {


### PR DESCRIPTION
Seeing an issue passing args to a script task

https://github.com/PeredurOmega/GradleNodePlugin/issues/6

What do you think of making the args type consistent with `DependenciesInstallTask.kt`