### PR TITLE
Use gradle delete to preserve symlinks

### DIFF
--- a/src/main/kotlin/NodeCleanTask.kt
+++ b/src/main/kotlin/NodeCleanTask.kt
@@ -22,6 +22,6 @@ abstract class NodeCleanTask : DefaultTask() {
 
     @TaskAction
     fun run() {
-        nodeModules.get().asFile.deleteRecursively()
+        delete(nodeModules.get().asFile)
     }
 }


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/working_with_files.html#sec:deleting_files_example

Uses the built in gradle delete task instead of `deleteRecursively`

`deleteRecursively` follows symlink. This is an issue with nx/lerna monorepos as the subpackages are symlinked. This was causing clean to delete all the packages as well as node_modules