### PR TITLE
Remove NodeService workingDir Parameter

### DIFF
--- a/src/main/kotlin/NodePlugin.kt
+++ b/src/main/kotlin/NodePlugin.kt
@@ -56,9 +56,7 @@ class NodePlugin : Plugin<Project> {
 
             // Register service to be able to launch and kill node processes / subprocess
             val serviceProvider =
-                project.gradle.sharedServices.registerIfAbsent(NodeService.NAME, NodeService::class.java) {
-                    parameters.workingDir.convention(extension.workingDir)
-                }
+                project.gradle.sharedServices.registerIfAbsent(NodeService.NAME, NodeService::class.java) {}
 
             // Read package json
             val packageJsonTxt = extension.packageJson.get().asFile.readText()

--- a/src/main/kotlin/NodeService.kt
+++ b/src/main/kotlin/NodeService.kt
@@ -8,7 +8,7 @@ import org.zeroturnaround.exec.ProcessExecutor
 import org.zeroturnaround.exec.stream.slf4j.Slf4jStream
 import java.io.File
 
-abstract class NodeService : BuildService<NodeService.Params>, AutoCloseable {
+abstract class NodeService : BuildService<BuildServiceParameters.None>, AutoCloseable {
 
     companion object {
         const val NAME = "nodeService"
@@ -41,12 +41,8 @@ abstract class NodeService : BuildService<NodeService.Params>, AutoCloseable {
         val outputStream = if (extensions.verbose.get()) LifecycleLoggerStream.of(logger) else Slf4jStream.of(logger).asInfo()
         process.redirectOutput(outputStream)
         process.redirectError(Slf4jStream.of(logger).asError())
-
+        process.directory(extensions.workingDir.get().asFile)
         return process
-    }
-
-    internal interface Params : BuildServiceParameters {
-        val workingDir: DirectoryProperty
     }
 
     private val processes = arrayListOf<Process>()
@@ -56,7 +52,6 @@ abstract class NodeService : BuildService<NodeService.Params>, AutoCloseable {
         /*workingDir?.let {
             nodeExecutor.directory(it)
         }*/
-        nodeExecutor.directory(parameters.workingDir.get().asFile)
         val process = nodeExecutor.start().process
         processes.add(process)
         return process


### PR DESCRIPTION
Our project contains multiple sub-projects which both utilize this plugin, and a `NodeScriptTask` in Project B is failing because an npm script cannot be found. Debug output revealed that the working directory of the task was incorrectly set to that of Project A, not Project B, and therefore was referencing the incorrect `package.json`.

Since the `NodeService` is registered as a shared build service (which I learned is [scoped to the build](https://docs.gradle.org/current/userguide/build_services.html#:~:text=Currently%2C%20build%20services%20are%20scoped%20to%20a%20build%2C%20rather%20than%20to%20a%20project), not the project), and because the `NodeService`'s `workingDir` is set at the time of registration, this means that all projects using this plugin will share the same `workingDir`.

This PR removes the `workingDir` param from the `NodeService` and instead applies it internally it via the plugin instance prior to task execution.